### PR TITLE
Update build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 apigateway
 =============
-[![Build Status](https://travis-ci.org/openwhisk/apigateway.svg?branch=master)](https://travis-ci.org/openwhisk/apigateway)
+[![Build Status](https://travis-ci.org/openwhisk/openwhisk-apigateway.svg?branch=master)](https://travis-ci.org/openwhisk/openwhisk-apigateway)
 
 A performant API Gateway based on Openresty and NGINX.
 

--- a/api-gateway-config/scripts/lua/policies/security/clientSecret.lua
+++ b/api-gateway-config/scripts/lua/policies/security/clientSecret.lua
@@ -18,9 +18,7 @@
 --   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 --   DEALINGS IN THE SOFTWARE.
 
---- @module mapping
--- Process mapping object, turning implementation details into request transformations
--- @author Cody Walker (cmwalker), Alex Song (songs)
+--- @module clientSecret
 
 local _M = {}
 

--- a/doc/policies.md
+++ b/doc/policies.md
@@ -113,8 +113,8 @@ Supported types: `apiKey, clientSecret`.
 _scope:_ `api`, `tenant`, `resource`.  
 _header:_ _(optional)_ custom name of auth header (default is x-api-key)  
 
-_keyLocation:_ _(optional)_ custom location for client secret keys. header, query_string (default is header)
-_idFieldName:_ _(optional)_ key for locating client id. default (X-Client-ID)
+_keyLocation:_ _(optional)_ custom location for client secret keys. header, query_string (default is header)  
+_idFieldName:_ _(optional)_ key for locating client id. default (X-Client-ID)  
 _secretFieldName:_ _(optional)_ key for locating client secret. default (X-Client-Secret)
 
 ```


### PR DESCRIPTION
Updated travis build status link in README to reflect the new name change to `openwhisk-apigateway`. Closes #79 