### PR TITLE
Fix proxy routing issue

### DIFF
--- a/api-gateway-config/scripts/lua/routing.lua
+++ b/api-gateway-config/scripts/lua/routing.lua
@@ -117,13 +117,13 @@ function _M.findRedisKey(resourceKeys, tenant, path)
           return key
         end
       end
-      -- substring redisKey upto last "/"
-      local index = redisKey:match("^.*()/")
-      if index == nil then
-        return nil
-      end
-      redisKey = string.sub(redisKey, 1, index - 1)
     end
+    -- substring redisKey upto last "/"
+    local index = redisKey:match("^.*()/")
+    if index == nil then
+      return nil
+    end
+    redisKey = string.sub(redisKey, 1, index - 1)
   end
   return nil
 end


### PR DESCRIPTION
Fixes additional issue related to #82. This fixes a bug where if the the gatewayPath that's passed in is longer than what's currently stored in redis for that tenant, the routing doesn't work properly. 
@mhamann @cmwalker PTAL