### PR TITLE
Handle hyphens for incoming proxy uri

### DIFF
--- a/api-gateway-config/scripts/lua/routing.lua
+++ b/api-gateway-config/scripts/lua/routing.lua
@@ -177,7 +177,9 @@ function setVerb(v)
 end
 
 function getUriPath(backendPath)
-  local i, j = ngx.var.uri:find(ngx.unescape_uri(ngx.var.gatewayPath))
+  local gatewayPath = ngx.unescape_uri(ngx.var.gatewayPath)
+  gatewayPath = gatewayPath:gsub('-', '%%-')
+  local _, j = ngx.var.uri:find(gatewayPath)
   local incomingPath = ((j and ngx.var.uri:sub(j + 1)) or nil)
   -- Check for backendUrl path
   if backendPath == nil or backendPath == '' or backendPath == '/' then


### PR DESCRIPTION
Fixes #98. The problem was that lua treats hyphens (`-`) as special characters, so we have to escape it. @codymwalker PTAL