### PR TITLE
Increase count for redis scan

### DIFF
--- a/api-gateway-config/scripts/lua/lib/redis.lua
+++ b/api-gateway-config/scripts/lua/lib/redis.lua
@@ -218,14 +218,14 @@ end
 -- @param tenantId tenant id
 function _M.getAllResourceKeys(red, tenantId)
   -- Find all resourceKeys in redis
-  local resources, err = red:scan(0, "match", utils.concatStrings({"resources:", tenantId, ":*"}))
+  local resources, err = red:scan(0, "match", utils.concatStrings({"resources:", tenantId, ":*"}), "count", 10000)
   if not resources then
     request.err(500, util.concatStrings({"Failed to retrieve resource keys: ", err}))
   end
   local cursor = resources[1]
   local resourceKeys = resources[2]
   while cursor ~= "0" do
-    resources, err = red:scan(cursor, "match", utils.concatStrings({"resources:", tenantId, ":*"}))
+    resources, err = red:scan(cursor, "match", utils.concatStrings({"resources:", tenantId, ":*"}), "count", 10000)
     if not resources then
       request.err(500, util.concatStrings({"Failed to retrieve resource keys: ", err}))
     end


### PR DESCRIPTION
Fixes #105. @codymwalker @mhamann 

Increased the `scan` count to 10,000 (default is 10), which dramatically reduced the response time. Below are the results from my lua profiler for an API invoke, with around ~100,000 keys in redis:

Before:
```
| TOTAL TIME = 2.323872
| FILE                                              : FUNCTION                                : LINE                : TIME        : RELATIVE    : CALLED      |
| /etc/api-gateway/scripts/lua/lib/redis.lua        : getAllResourceKeys                      :  218                : 2.317       : 99.72%      :       1     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : scan                                    :  166                : 1.111       : 47.82%      :   10575     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : _read_reply                             :  166                : 0.521       : 22.41%      :   21151     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : _gen_req                                :  248                : 0.280       : 12.03%      :   10577     |
| /etc/api-gateway/scripts/lua/lib/redis.lua        : init                                    :   42                : 0.005       : 0.24%       :       1     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : anonymous                               :    0                : 0.004       : 0.19%       :       1     |
...
```

After:
```
| TOTAL TIME = 0.004482
| FILE                                              : FUNCTION                                : LINE                : TIME        : RELATIVE    : CALLED      |
| /etc/api-gateway/scripts/lua/lib/redis.lua        : getAllResourceKeys                      :  218                : 0.003       : 76.55%      :       1     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : scan                                    :  166                : 0.002       : 37.10%      :      12     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : _read_reply                             :  166                : 0.001       : 16.69%      :      25     |
| /usr/local/api-gateway/lualib/resty/redis.lua     : _gen_req                                :  248                : 0.001       : 12.52%      :      14     |
| /etc/api-gateway/scripts/lua/lib/redis.lua        : init                                    :   42                : 0.000       : 9.33%       :       1     |
| /usr/local/api-gateway/lualib/url.lua             : parse                                   :  286                : 0.000       : 3.41%       :       1     |
...
```

Note that by increasing the count, however, we will be blocking other calls to redis while it scans through redis for those 10,000 keys.

Assuming we have around ~1M keys in redis, the number of calls to redis will increase by 10x, which will slow down the response time a bit.