### PR TITLE
Add dynamic backend routing

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -25,6 +25,7 @@ server {
     listen 8080 default_server;
 
     server_tokens off;
+    ignore_invalid_headers off;
 
     #turn off the uninitialized_variable_warn ,as it writes to error_log , hence io
     uninitialized_variable_warn off;
@@ -70,7 +71,7 @@ server {
             local routing = require "routing"
             routing.processCall()
             local cors = require "cors"
-            ngx.var.cors, ngx.var.cors_methods = cors.processCall(ngx.var["tenant"], ngx.var["gatewayPath"])   
+            ngx.var.cors, ngx.var.cors_methods = cors.processCall(ngx.var["tenant"], ngx.var["gatewayPath"])
         }
         
         proxy_pass $upstream;

--- a/scripts/lua/management/apis.lua
+++ b/scripts/lua/management/apis.lua
@@ -231,22 +231,22 @@ end
 -- @param security security object
 function checkOptionalPolicies(policies, security)
   if policies then
-    for k, v in pairs(policies) do
-      local validTypes = {reqMapping = true, rateLimit = true}
+    for _, v in pairs(policies) do
+      local validTypes = {"reqMapping", "rateLimit", "backendRouting"}
       if (v.type == nil or v.value == nil) then
-        return false, { statusCode = 400, message = "Missing field in policy object. Need \"type\" and \"scope\"." }
-      elseif validTypes[v.type] == nil then
-        return false, { statusCode = 400, message = "Invalid type in policy object. Valid: \"reqMapping\", \"rateLimit\"" }
+        return false, { statusCode = 400, message = "Missing field in policy object. Need \"type\" and \"value\"." }
+      elseif utils.tableContains(validTypes, v.type) == false then
+        return false, { statusCode = 400, message = "Invalid type in policy object. Valid types: " .. cjson.encode(validTypes) }
       end
     end
   end
   if security then
-    for k, sec in ipairs(security) do
-      local validScopes = {tenant=true, api=true, resource=true}
+    for _, sec in ipairs(security) do
+      local validScopes = {"tenant", "api", "resource"}
       if (sec.type == nil or sec.scope == nil) then
         return false, { statusCode = 400, message = "Missing field in security object. Need \"type\" and \"scope\"." }
-      elseif validScopes[sec.scope] == nil then
-        return false, { statusCode = 400, message = "Invalid scope in security object. Valid: \"tenant\", \"api\", \"resource\"." }
+      elseif utils.tableContains(validScopes, sec.scope) == false == nil then
+        return false, { statusCode = 400, message = "Invalid scope in security object. Valid scopes:" .. cjson.encode(validScopes) }
       end
     end 
   end

--- a/scripts/lua/policies/backendRouting.lua
+++ b/scripts/lua/policies/backendRouting.lua
@@ -1,0 +1,89 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+--- @module backendRouting
+-- Used to set the backend Url either statically or dynamically
+
+local url = require "url"
+local utils = require "lib/utils"
+local request = require "lib/request"
+local logger = require "lib/logger"
+
+local _M = {}
+
+--- Set upstream based on the backendUrl
+function _M.setRoute(backendUrl)
+  local u = url.parse(backendUrl)
+  if u.scheme == nil then
+    u = url.parse(utils.concatStrings({'http://', backendUrl}))
+  end
+  ngx.var.backendUrl = backendUrl
+  ngx.req.set_uri(getUriPath(u.path))
+  setUpstream(u)
+end
+
+--- Set dynamic route based on the based on the header that is passed in
+function _M.setDynamicRoute(obj)
+  local whitelist = obj.whitelist
+  for k in pairs(whitelist) do
+    whitelist[k] = whitelist[k]:lower()
+  end
+  local header = obj.header ~= nil and obj.header or 'X-Cf-Forwarded-Url'
+  local dynamicBackend = ngx.req.get_headers()[header];
+  if dynamicBackend ~= nil and dynamicBackend ~= '' then
+    local u = url.parse(dynamicBackend)
+    if u.scheme == nil or u.scheme == '' then
+      u = url.parse(utils.concatStrings({'http://', dynamicBackend}))
+    end
+    if utils.tableContains(whitelist, u.host) then
+      ngx.req.set_uri(getUriPath(u.path))
+      setUpstream(u)
+    else
+      request.err(403, 'Dynamic backend host not part of whitelist.')
+    end
+  else
+    logger.info('Header for dynamic routing not found. Defaulting to backendUrl.')
+  end
+end
+
+function getUriPath(backendPath)
+  local gatewayPath = ngx.unescape_uri(ngx.var.gatewayPath)
+  gatewayPath = gatewayPath:gsub('-', '%%-')
+  local _, j = ngx.var.request_uri:find(gatewayPath)
+  local incomingPath = ((j and ngx.var.request_uri:sub(j + 1)) or nil)
+  -- Check for backendUrl path
+  if backendPath == nil or backendPath == '' or backendPath == '/' then
+    incomingPath = (incomingPath and incomingPath ~= '') and incomingPath or '/'
+    incomingPath = string.sub(incomingPath, 1, 1) == '/' and incomingPath or utils.concatStrings({'/', incomingPath})
+    return incomingPath
+  else
+    return utils.concatStrings({backendPath, incomingPath})
+  end
+end
+
+function setUpstream(u)
+  local upstream = utils.concatStrings({u.scheme, '://', u.host})
+  if u.port ~= nil and u.port ~= '' then
+    upstream = utils.concatStrings({upstream, ':', u.port})
+  end
+  ngx.var.upstream = upstream
+end
+
+return _M

--- a/scripts/lua/policies/mapping.lua
+++ b/scripts/lua/policies/mapping.lua
@@ -28,10 +28,10 @@ local cjson = require "cjson"
 
 local _M = {}
 
-local body = nil
-local query = nil
-local headers = nil
-local path = nil
+local body
+local query
+local headers
+local path
 
 --- Implementation for the mapping policy.
 -- @param map The mapping object that contains details about request tranformations


### PR DESCRIPTION
Closes #86. @codymwalker @mhamann PTAL.

Added `backendRouting` policy. You define it as follows inside the policies array:
```
"policies": [{
  "type": "backendRouting",
  "value": {
    "header": "x-backend-test-header",
    "whitelist": ["httpbin.org"]
  }
},
...
]
```
- The `header` field is optional. If not defined, it defaults to `X-Cf-Forwarded-Url` for cf route services.
- When you invoke this API, you will have to set the `header` (in this example, `x-backend-test-header`) with a new backendUrl as its value
- `whitelist` is an array of allowed hosts that can be used for the new backendUrl value