### PR TITLE
Add tenant namespace and instance to api doc

### DIFF
--- a/conf.d/api_gateway_logging.conf
+++ b/conf.d/api_gateway_logging.conf
@@ -29,4 +29,4 @@ log_format  platform  '$remote_addr - remote_user="$remote_user" [$time_local] r
                       'status=$status bbs=$body_bytes_sent rl=$request_length rt=$request_time hr="$http_referer" '
                       'ua="$http_user_agent" xfwdf="$http_x_forwarded_for" '
                       'upadd="$upstream_addr" upstat=$upstream_status uprt=$upstream_response_time '
-                      'tenantId="$tenant" reqid="$requestId"';
+                      'tenantId="$tenant" tenantNamespace="$tenantNamespace" tenantInstance="$tenantInstance" reqid="$requestId"';

--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -62,6 +62,8 @@ server {
     location ~ "^/api/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\/\-\_\{\} ]+)(\\b)" {
         set $upstream https://172.17.0.1;
         set $tenant $1;
+        set $tenantNamespace '';
+        set $tenantInstance '';
         set $backendUrl '';
         set $gatewayPath $2;
         set $cors '';

--- a/scripts/lua/cors.lua
+++ b/scripts/lua/cors.lua
@@ -39,8 +39,11 @@ function processCall(tenant, gatewayPath)
     return nil, nil
   end 
 
-  local apiConfig = cjson.decode(red:hget('apis', resourceConfig.apiId))
-
+  local apiConfig = red:hget('apis', resourceConfig.apiId)
+  if apiConfig == ngx.null then
+    return nil, nil
+  end
+  apiConfig = cjson.decode(apiConfig)
   -- if they didn't set an apiId inside of their resource, we can't do this.. just silently error out
   if apiConfig.cors == nil then
     return nil, nil

--- a/scripts/lua/lib/redis.lua
+++ b/scripts/lua/lib/redis.lua
@@ -168,7 +168,8 @@ end
 --- Generate Redis object for resource
 -- @param ops list of operations for a given resource
 -- @param apiId resource api id (nil if no api)
-function _M.generateResourceObj(ops, apiId)
+-- @param tenantObj tenant information
+function _M.generateResourceObj(ops, apiId, tenantObj)
   local resourceObj = {
     operations = {}
   }
@@ -187,6 +188,11 @@ function _M.generateResourceObj(ops, apiId)
   end
   if apiId then
     resourceObj.apiId = apiId
+  end
+  if tenantObj then
+    resourceObj.tenantId = tenantObj.id
+    resourceObj.tenantNamespace = tenantObj.namespace
+    resourceObj.tenantInstance = tenantObj.instance
   end
   return cjson.encode(resourceObj)
 end

--- a/scripts/lua/management/apis.lua
+++ b/scripts/lua/management/apis.lua
@@ -100,11 +100,14 @@ function addAPI()
   if basePath:sub(1,1) ~= '' then
     managedUrl = utils.concatStrings({managedUrl, "/", basePath})
   end
+  local tenantObj = redis.getTenant(red, decoded.tenantId)
   local managedUrlObj = {
     id = uuid,
     name = decoded.name,
     basePath = utils.concatStrings({"/", basePath}),
     tenantId = decoded.tenantId,
+    tenantNamespace = tenantObj.namespace,
+    tenantInstance = tenantObj.instance,
     cors = decoded.cors, 
     resources = decoded.resources,
     managedUrl = managedUrl
@@ -115,7 +118,7 @@ function addAPI()
   for path, resource in pairs(decoded.resources) do
     local gatewayPath = utils.concatStrings({basePath, path})
     gatewayPath = (gatewayPath:sub(1,1) == '/') and gatewayPath:sub(2) or gatewayPath
-    resources.addResource(red, resource, gatewayPath, decoded.tenantId)
+    resources.addResource(red, resource, gatewayPath, tenantObj)
   end
   redis.close(red)
   -- Return managed url object

--- a/scripts/lua/management/resources.lua
+++ b/scripts/lua/management/resources.lua
@@ -31,14 +31,13 @@ local _M = {}
 -- @param red
 -- @param resource
 -- @param gatewayPath
--- @param tenantId
-function _M.addResource(red, resource, gatewayPath, tenantId)
+-- @param tenantObj
+function _M.addResource(red, resource, gatewayPath, tenantObj)
   -- Create resource object and add to redis
-  local redisKey = utils.concatStrings({"resources", ":", tenantId, ":", gatewayPath})
-  local apiId
+  local redisKey = utils.concatStrings({"resources", ":", tenantObj.id, ":", gatewayPath})
   local operations = resource.operations
   local apiId = resource.apiId
-  local resourceObj = redis.generateResourceObj(operations, apiId)
+  local resourceObj = redis.generateResourceObj(operations, apiId, tenantObj)
   redis.createResource(red, redisKey, REDIS_FIELD, resourceObj)
 end
 

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -47,6 +47,8 @@ function _M.processCall()
     request.err(404, 'Not found.')
   end
   local obj = cjson.decode(redis.getResource(red, redisKey, "resources"))
+  ngx.var.tenantNamespace = obj.tenantNamespace
+  ngx.var.tenantInstance = obj.tenantInstance
   for verb, opFields in pairs(obj.operations) do
     if string.upper(verb) == ngx.req.get_method() then
       -- Check if auth is required

--- a/tests/scripts/lua/lib/redis.lua
+++ b/tests/scripts/lua/lib/redis.lua
@@ -101,6 +101,21 @@ describe('Testing Redis module', function()
     expected = resourceObj
     generated = cjson.decode(redis.generateResourceObj(operations, apiId))
     assert.are.same(expected, generated)
+
+    local tenantObj = [[
+      {
+        "id": "123",
+        "namespace": "testname",
+        "instance": "testinstance"
+      }
+    ]]
+    tenantObj = cjson.decode(tenantObj)
+    resourceObj.tenantId = tenantObj.id
+    resourceObj.tenantNamespace = tenantObj.namespace
+    resourceObj.tenantInstance = tenantObj.instance
+    expected = resourceObj
+    generated = cjson.decode(redis.generateResourceObj(operations, apiId, tenantObj))
+    assert.are.same(expected, generated)
   end)
 
   it('should get a resource from redis', function()


### PR DESCRIPTION
Fixes #127 @mhamann @codymwalker PTAL
`access.log` now logs additional `tenantNamespace` and `tenantInstance` fields.