### PR TITLE
Improve efficiency of getting resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ services:
   - docker
 
 before_install:
-  - ./tools/travis/setup.sh
+#  - ./tools/travis/setup.sh
   - pip install hererocks
   - hererocks lua_install -r^ --$LUA
   - export PATH=$PATH:$PWD/lua_install/bin # Add directory with all installed binaries to PATH
-  
+
 
 install:
   - cd tests
@@ -24,4 +24,4 @@ install:
 
 script:
   - busted --output=TAP --helper=set_paths --pattern=.lua scripts
-  - ../tools/travis/build.sh
+#  - ../tools/travis/build.sh

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ DOCKER_TAG ?= snapshot-`date +'%Y%m%d-%H%M'`
 DOCKER_REGISTRY ?= ''
 
 docker:
-	docker build -t openwhisk/openwhisk-apigateway .
+	docker build -t openwhisk/apigateway .
 
 .PHONY: docker-ssh
 docker-ssh:
-	docker run -ti --entrypoint='bash' openwhisk/openwhisk-apigateway:latest
+	docker run -ti --entrypoint='bash' openwhisk/apigateway:latest
 
 .PHONY: test-build
 test-build:
@@ -18,13 +18,13 @@ test-run:
 
 .PHONY: docker-run
 docker-run:
-	docker run --rm --name="openwhisk-apigateway" -p 80:80 -p ${PUBLIC_MANAGEDURL_PORT}:8080 -p 9000:9000 \
+	docker run --rm --name="apigateway" -p 80:80 -p ${PUBLIC_MANAGEDURL_PORT}:8080 -p 9000:9000 \
 		-e PUBLIC_MANAGEDURL_HOST=${PUBLIC_MANAGEDURL_HOST} -e PUBLIC_MANAGEDURL_PORT=${PUBLIC_MANAGEDURL_PORT} \
 		-e REDIS_HOST=${REDIS_HOST} -e REDIS_PORT=${REDIS_PORT} -e REDIS_PASS=${REDIS_PASS} \
 		-e TOKEN_GOOGLE_URL=https://www.googleapis.com/oauth2/v3/tokeninfo \
 	 	-e TOKEN_FACEBOOK_URL=https://graph.facebook.com/debug_token \
 		-e TOKEN_GITHUB_URL=https://api.github.com/user \
-		openwhisk/openwhisk-apigateway:latest
+		openwhisk/apigateway:latest
 
 .PHONY: docker-debug
 docker-debug:
@@ -36,7 +36,7 @@ docker-debug:
 			-p 80:80 -p 5000:5000 \
 			-e "LOG_LEVEL=info" -e "DEBUG=true" \
 			-v ${HOME}/tmp/apiplatform/apigateway/:/etc/api-gateway \
-			openwhisk/openwhisk-apigateway:latest ${DOCKER_ARGS}
+			openwhisk/apigateway:latest ${DOCKER_ARGS}
 
 .PHONY: docker-reload
 docker-reload:
@@ -52,4 +52,3 @@ docker-attach:
 docker-stop:
 	docker stop apigateway
 	docker rm apigateway
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is currently considered pre-alpha stage, and should not be used in 
 
 
 ## Table of Contents
- 
+
 * [Quick Start](#quick-start)
 * [API](#api)
 * [Developer Guide](#developer-guide)
@@ -27,7 +27,7 @@ docker run -p 80:80 -p <managedurl_port>:8080 -p 9000:9000 \
             -e REDIS_HOST=<redis_host> \
             -e REDIS_PORT=<redis_port> \
             -e REDIS_PASS=<redis_pass> \
-            openwhisk/openwhisk-apigateway:latest
+            openwhisk/apigateway:latest
 ```
 
 ## API
@@ -51,7 +51,7 @@ docker run -p 80:80 -p <managedurl_port>:8080 -p 9000:9000 \
     REDIS_HOST=<redis_host> REDIS_PORT=<redis_port> REDIS_PASS=<redis_pass>
  ```
 
- 
+
 ### Testing
 
  First install the necessary dependencies:
@@ -62,4 +62,3 @@ docker run -p 80:80 -p <managedurl_port>:8080 -p 9000:9000 \
  ```
   make test-run
  ```
-

--- a/scripts/lua/management/lib/resources.lua
+++ b/scripts/lua/management/lib/resources.lua
@@ -34,11 +34,13 @@ local _M = {}
 -- @param tenantObj
 function _M.addResource(red, resource, gatewayPath, tenantObj)
   -- Create resource object and add to redis
-  local redisKey = utils.concatStrings({"resources", ":", tenantObj.id, ":", gatewayPath})
+  local redisKey = utils.concatStrings({"resources:", tenantObj.id, ":", gatewayPath})
   local operations = resource.operations
   local apiId = resource.apiId
   local resourceObj = redis.generateResourceObj(operations, apiId, tenantObj)
   redis.createResource(red, redisKey, REDIS_FIELD, resourceObj)
+  local indexKey = utils.concatStrings({"resources:", tenantObj.id, ":__index__"})
+  redis.addResourceToIndex(red, indexKey, redisKey)
 end
 
 --- Helper function for deleting resource in redis and appropriate conf files
@@ -48,6 +50,8 @@ end
 function _M.deleteResource(red, gatewayPath, tenantId)
   local redisKey = utils.concatStrings({"resources:", tenantId, ":", gatewayPath})
   redis.deleteResource(red, redisKey, REDIS_FIELD)
+  local indexKey = utils.concatStrings({"resources:", tenantId, ":__index__"})
+  redis.deleteResourceFromIndex(red, indexKey, redisKey)
 end
 
 return _M

--- a/scripts/lua/management/routes/apis.lua
+++ b/scripts/lua/management/routes/apis.lua
@@ -175,7 +175,7 @@ function deleteAPI()
   local version = ngx.var.version
   if version == 'v1' then
     redis.close(red)
-    request.success(200, {})
+    request.success(200, cjson.encode({}))
   elseif version == 'v2' then
     redis.deleteSwagger(red, id)
     redis.close(red)


### PR DESCRIPTION
Fixes #107. @mhamann @codymwalker PTAL

When an API is created, a `resources:<tenantId>:__index__` set is created and all resource keys associated with that API is added to this set. This way, when a resource of that API is invoked, it first looks up that `resources:<tenantId>:__index__` set and performs the lookup algorithm on just the resources in that set. This prevents scanning through the entire redis database.

The same change of creating `resources:<tenantId>:__index__` and adding resource keys to this set  has to be implemented for the cloud case as well. @gclyne Can you take a look at adding this to your component?