### PR TITLE
Fix analytics logging

### DIFF
--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -44,7 +44,8 @@ function _M.processCall()
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 10000)
   local tenantId = ngx.var.tenant
   local gatewayPath = ngx.var.gatewayPath
-  ngx.var.analyticsUri = ngx.var.request_uri:gsub("/api/([^/]+)", "")
+  local i, j = ngx.var.request_uri:find("/api/([^/]+)")
+  ngx.var.analyticsUri = ngx.var.request_uri:sub(j+1)
   local resourceKeys = redis.getAllResourceKeys(red, tenantId)
   local redisKey = _M.findRedisKey(resourceKeys, tenantId, gatewayPath)
   if redisKey == nil then


### PR DESCRIPTION
@codymwalker PTAL

`gsub` is global substitution, meaning that it will replace all instances of the pattern in the string. I've modified it to use `find` to get the start and end index of the first occurrence of the pattern, and then take the substring after that pattern.