### PR TITLE
Add cors preflight logic

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -76,27 +76,9 @@ server {
         access_by_lua_block {
             local routing = require "routing"
             routing.processCall()
-            local cors = require "cors"
-            ngx.var.cors, ngx.var.cors_methods = cors.processCall(ngx.var["tenant"], ngx.var["gatewayPath"])
         }
 
         proxy_pass $upstream;
-
-        header_filter_by_lua_block {
-          if ngx.var.cors ~= nil then
-            if ngx.var.cors == 'false' then
-              ngx.header['Access-Control-Allow-Origin'] = nil
-              ngx.header['Access-Control-Allow-Methods'] = nil
-            else
-              ngx.header['Access-Control-Allow-Origin'] = ngx.var.cors
-              if ngx.var.cors_methods ~= nil then
-                ngx.header['Access-Control-Allow-Methods'] = ngx.var.cors_methods
-              else
-                ngx.header['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS'
-              end
-            end
-          end
-        }
     }
 
     location = /health {

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -31,6 +31,7 @@ local security = require "policies/security"
 local mapping = require "policies/mapping"
 local rateLimit = require "policies/rateLimit"
 local backendRouting = require "policies/backendRouting"
+local cors = require "cors"
 
 local REDIS_HOST = os.getenv("REDIS_HOST")
 local REDIS_PORT = os.getenv("REDIS_PORT")
@@ -52,6 +53,7 @@ function _M.processCall()
     request.err(404, 'Not found.')
   end
   local obj = cjson.decode(redis.getResource(red, redisKey, "resources"))
+  cors.processCall(obj)
   redis.close(red)
   ngx.var.tenantNamespace = obj.tenantNamespace
   ngx.var.tenantInstance = obj.tenantInstance


### PR DESCRIPTION
@mhamann @codymwalker @taylorking PTAL

Updated the routing logic to return the appropriate CORS response headers for `options` preflight requests as well as for the actual requests.
