### PR TITLE
Add api key to access log with client secret enabled

### DIFF
--- a/scripts/lua/policies/security/clientSecret.lua
+++ b/scripts/lua/policies/security/clientSecret.lua
@@ -80,6 +80,7 @@ function processWithHashFunction(red, securityObj, hashFunction)
   if result == nil then  
     request.err(401, "Secret mismatch or not subscribed to this api.")
   end
+  ngx.var.apiKey = clientId
   return result
 end
 


### PR DESCRIPTION
Fixes #171. @codymwalker @mhamann PTAL 
The problem was that `ngx.var.apiKey` was getting set in the `apiKey` security policy but not in the `clientSecret` policy