### PR TITLE
Add support for X-Debug-Mode header

### DIFF
--- a/conf.d/api_gateway_logging.conf
+++ b/conf.d/api_gateway_logging.conf
@@ -32,4 +32,5 @@ log_format  platform  '$remote_addr - remote_user="$remote_user" [$time_local] r
                       'ua="$http_user_agent" xfwdf="$http_x_forwarded_for" '
                       'upadd="$upstream_addr" upstat=$upstream_status uprt=$upstream_response_time '
                       'tenantId="$tenant" tenantNamespace="$tenantNamespace" tenantInstance="$tenantInstance" '
+                      'requestHeaders="$requestHeaders" requestBody="$requestBody" responseHeaders="$responseHeaders" responseBody="$responseBody" '
                       'apiId="$apiId" apiKey="$apiKey" analyticsUri="$analyticsUri" reqid="$requestId"';

--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -72,6 +72,10 @@ server {
         set $analyticsUri '';
         set $cors_origins '';
         set $cors_methods '';
+        set $requestHeaders '';
+        set $requestBody '';
+        set $responseHeaders '';
+        set $responseBody '';
 
         access_by_lua_block {
             local routing = require "routing"
@@ -79,13 +83,21 @@ server {
         }
 
         proxy_pass $upstream;
-        header_filter_by_lua_block { 
+        header_filter_by_lua_block {
             local cors = require "cors"
             cors.replaceHeaders()
+        }
+
+        body_filter_by_lua_block {
+          local routing = require "routing"
+          if ngx.req.get_headers()["x-debug-mode"] == "true" then
+            routing.setResponseLogs()
+          end
         }
     }
 
     location = /health {
+        access_log off;
         proxy_pass http://0.0.0.0:9000/v1/health-check;
     }
 }

--- a/conf.d/management_apis.conf
+++ b/conf.d/management_apis.conf
@@ -62,6 +62,7 @@ server {
     }
 
     location /v1/health-check {
+        access_log off;
         access_by_lua_block {
             local requestMethod = ngx.req.get_method()
             if requestMethod == "GET" then


### PR DESCRIPTION
Fixes #173 @mhamann @codymwalker PTAL
Changes:
* To see the `requestHeaders`, `requestBody`, `responseHeaders`, and `responseBody` in the access logs, invoke the API with the `X-Debug-Mode` header
* Appended query parameters to cf analytics uri that's being logged
* Disabled logging for health check because it was cluttering up the logs
