### PR TITLE
Add subscriptions api for v2 interface

### DIFF
--- a/conf.d/management_apis.conf
+++ b/conf.d/management_apis.conf
@@ -53,12 +53,19 @@ server {
             tenants.requestHandler()
         }
     }
-
-    location /v1/subscriptions {
-         access_by_lua_block {
-             local subscriptions = require("management/routes/subscriptions")
-             subscriptions.requestHandler()
-         }
+    
+    location ~ /(?<version>v2)/(?<tenant_id>[^/]*)/subscriptions/?(?<client_id>[^/]*)?/? {
+        access_by_lua_block {
+            local subscriptions = require("management/routes/subscriptions")
+            subscriptions.requestHandler()
+        }
+    }
+    
+    location ~ /(?<version>v1)/subscriptions/? {
+        access_by_lua_block {
+            local subscriptions = require("management/routes/subscriptions")
+            subscriptions.requestHandler()
+        }
     }
 
     location /v1/health-check {

--- a/doc/policies.md
+++ b/doc/policies.md
@@ -23,7 +23,7 @@ Example:
     "interval": 60,
     "rate": 120,
     "scope": "api"
-    "subscription": "true"
+    "subscription": true
   }
 }
 ```

--- a/scripts/lua/lib/utils.lua
+++ b/scripts/lua/lib/utils.lua
@@ -107,5 +107,18 @@ function _Utils.tableContainsAll(table, requiredFields)
   return true
 end
 
+--- Takes a string and performs a SHA256 hash on its input
+-- @param str the string to input into the hash function
+-- @returns a hashed string
+function _Utils.hash(str) 
+  local resty_sha256 = require "resty.sha256"
+  local resty_str = require "resty.string" 
+
+  local sha256 = resty_sha256:new() 
+  sha256:update(str)
+  local digest = sha256:final()
+  return resty_str.to_hex(digest)
+end 
+
 return _Utils
 

--- a/scripts/lua/management/lib/subscriptions.lua
+++ b/scripts/lua/management/lib/subscriptions.lua
@@ -1,0 +1,76 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+--- @module subscriptions
+-- Management interface for subscriptions for the gateway
+
+local redis = require "lib/redis"
+local utils = require "lib/utils"
+
+local _M = {}
+
+function _M.addSubscription(red, artifactId, tenantId, clientId, clientSecret, hashFunction)
+  local subscriptionKey = utils.concatStrings({"subscriptions:tenant:", tenantId, ":api:", artifactId})
+  if clientSecret ~= nil then
+    if hashFunction == nil then
+      hashFunction = utils.hash
+    end
+    subscriptionKey = utils.concatStrings({subscriptionKey, ":clientsecret:", clientId, ":", hashFunction(clientSecret)})
+  else
+    subscriptionKey = utils.concatStrings({subscriptionKey, ":key:", clientId})
+  end
+  redis.createSubscription(red, subscriptionKey)
+end
+
+function _M.getSubscriptions(red, artifactId, tenantId)
+  local res = red:scan(0, "match", utils.concatStrings({"subscriptions:tenant:", tenantId, ":api:", artifactId, ":*"}))
+  local cursor = res[1]
+  local subscriptions = {}
+  for _, v in pairs(res[2]) do
+    local matched = {string.match(v, "subscriptions:tenant:([^:]+):api:([^:]+):([^:]+):([^:]+):*")}
+    subscriptions[#subscriptions + 1] = matched[4]
+  end
+  while cursor ~= "0" do
+    res = red:scan(cursor, "match", utils.concatStrings({"subscriptions:tenant:", tenantId, ":api:", artifactId, ":*"}))
+    cursor = res[1]
+    for _, v in pairs(res[2]) do
+      local matched = {string.match(v, "subscriptions:tenant:([^:]+):api:([^:]+):([^:]+):([^:]+):*")}
+      subscriptions[#subscriptions + 1] = matched[4]
+    end
+  end
+  return subscriptions
+end
+
+function _M.deleteSubscription(red, artifactId, tenantId, clientId)
+  local subscriptionKey = utils.concatStrings({"subscriptions:tenant:", tenantId, ":api:", artifactId})
+  local key = utils.concatStrings({subscriptionKey, ":key:", clientId})
+  if redis.exists(red, key) == 1 then
+    redis.deleteSubscription(red, key)
+  else
+    local pattern = utils.concatStrings({subscriptionKey, ":clientsecret:" , clientId, ":*"})
+    local res = red:eval("return redis.call('del', unpack(redis.call('keys', ARGV[1])))", 0, pattern)
+    if res == false then
+      return false
+    end
+  end
+  return true
+end
+
+return _M

--- a/scripts/lua/management/lib/swagger.lua
+++ b/scripts/lua/management/lib/swagger.lua
@@ -117,7 +117,7 @@ function parseRateLimit(swagger, policies)
         interval = rlObj.unit * rlObj.units,
         rate = rlObj.rate,
         scope = "api",
-        subscription = "true"
+        subscription = true
       }
     }
   end

--- a/scripts/lua/policies/security/clientSecret.lua
+++ b/scripts/lua/policies/security/clientSecret.lua
@@ -37,7 +37,7 @@ local REDIS_PASS = os.getenv("REDIS_PASS")
 --@return a string representation of what this looks like in redis :clientsecret:clientid:hashed secret
 function process(securityObj)
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
-  local result = processWithHashFunction(red, securityObj, hash)
+  local result = processWithHashFunction(red, securityObj, utils.hash)
   redis.close(red)
   return result
 end 
@@ -84,20 +84,6 @@ function processWithHashFunction(red, securityObj, hashFunction)
   ngx.var.apiKey = clientId
   return result
 end
-
-
---- Takes a string and performs a SHA256 hash on it's input
--- @param str the string to input into the hash function
--- @returns a hashed string
-function hash(str) 
-  local resty_sha256 = require "resty.sha256"
-  local resty_str = require "resty.string" 
-
-  local sha256 = resty_sha256:new() 
-  sha256:update(str)
-  local digest = sha256:final()
-  return resty_str.to_hex(digest)
-end 
 
 --- Validate that the subscription exists in redis
 -- @param tenant the tenantId we are checking for 

--- a/tests/scripts/lua/lib/subscriptions.lua
+++ b/tests/scripts/lua/lib/subscriptions.lua
@@ -1,0 +1,69 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+local cjson = require "cjson"
+local fakengx = require "fakengx"
+local fakeredis = require "fakeredis"
+local subscriptions = require "management/lib/subscriptions"
+local utils = require "lib/utils"
+
+describe("Testing v2 subscriptions API", function()
+  before_each(function()
+    _G.ngx = fakengx.new()
+    red = fakeredis.new()
+  end)
+
+  it("should create a new subscription", function()
+    -- client id only
+    local artifactId = "abc"
+    local tenantId = "testtenant"
+    local clientId = "xxx"
+    subscriptions.addSubscription(red, artifactId, tenantId, clientId)
+    local generated = red:exists("subscriptions:tenant:" .. tenantId .. ":api:" .. artifactId .. ":key:" .. clientId)
+    assert.are.equal(1, generated)
+    -- client id and secret
+    local newClientId = "newclientid"
+    local clientSecret = "secret"
+    subscriptions.addSubscription(red, artifactId, tenantId, newClientId, clientSecret, generateHash)
+    generated = red:exists("subscriptions:tenant:" .. tenantId .. ":api:" .. artifactId .. ":clientsecret:" .. newClientId .. ":" .. generateHash(clientSecret))
+    assert.are.equal(1, generated)
+    -- wrong secret
+    local badsecret = "badsecret"
+    generated = red:exists("subscriptions:tenant:" .. tenantId .. ":api:" .. artifactId .. ":clientsecret:" .. newClientId .. ":" .. generateHash(badsecret))
+    assert.are.equal(0, generated)
+  end)
+  
+  it("should delete a subscription", function()
+    local artifactId = "abc"
+    local tenantId = "testtenant"
+    local clientId = "12345"
+    subscriptions.addSubscription(red, artifactId, tenantId, clientId)
+    local generated = red:exists("subscriptions:tenant:" .. tenantId .. ":api:" .. artifactId .. ":key:" .. clientId)
+    assert.are.same(1, generated)
+    subscriptions.deleteSubscription(red, artifactId, tenantId, clientId)
+    generated = red:exists("subscriptions:tenant:" .. tenantId .. ":api:" .. artifactId .. ":key:" .. clientId)
+    assert.are.same(0, generated)
+  end)
+end)
+
+-- Generate fake hash
+function generateHash(str)
+  return string.byte(str)*13 + 2961
+end

--- a/tests/scripts/lua/management/examples/example1.json
+++ b/tests/scripts/lua/management/examples/example1.json
@@ -46,19 +46,11 @@
       "type": "apiKey",
       "name": "X-Api-Key",
       "in": "header"
-    },
-    "google": {
-      "type": "oauth2",
-      "flow": "tokenIntrospect",
-      "x-tokenintrospect": {
-        "url": "https://www.googleapis.com/oauth2/v3/tokeninfo"
-      }
     }
   },
   "security": [
     {
-      "client_id": [],
-      "google": []
+      "client_id": []
     }
   ],
   "x-gateway-rate-limit": [

--- a/tests/scripts/lua/management/examples/example2.json
+++ b/tests/scripts/lua/management/examples/example2.json
@@ -63,12 +63,10 @@
       "name": "X-Api-Key",
       "in": "header"
     },
-    "google": {
-      "type": "oauth2",
-      "flow": "tokenIntrospect",
-      "x-tokenintrospect": {
-        "url": "https://www.googleapis.com/oauth2/v3/tokeninfo"
-      }
+    "client_secret": {
+      "type": "apiKey",
+      "name": "X-Api-Secret",
+      "in": "header"
     }
   },
   "security": [

--- a/tests/scripts/lua/management/lib/swagger.lua
+++ b/tests/scripts/lua/management/lib/swagger.lua
@@ -42,18 +42,13 @@ describe('Testing v2 management interface', function()
                     "type": "rateLimit",
                     "value": {
                       "scope": "api",
-                      "subscription": "true",
+                      "subscription": true,
                       "interval": 180,
                       "rate": 100
                     }
                   }
                 ],
                 "security": [
-                  {
-                    "type": "oauth2",
-                    "provider": "google",
-                    "scope": "api"
-                  },
                   {
                     "type": "apiKey",
                     "header": "X-Api-Key",
@@ -109,14 +104,10 @@ describe('Testing v2 management interface', function()
                   ],
                   "security": [
                     {
-                      "type": "oauth2",
-                      "provider": "google",
-                      "scope": "api"
-                    },
-                    {
-                      "type": "apiKey",
-                      "header": "X-Api-Key",
-                      "scope": "api"
+                      "type": "clientSecret",
+                      "scope": "api",
+                      "idFieldName":"X-Api-Key",
+                      "secretFieldName":"X-Api-Secret"
                     }
                   ],
                   "backendMethod": "post"


### PR DESCRIPTION
Fixes #104. Fixes #72. @mhamann @codymwalker PTAL

* Added new v2 API for managing subscriptions (client id and client secret)

  - POST /v2/{tenant_id}/subscriptions
  ```
    {
      artifact_id: *(string),
      client_id: *(string),
      client_secret: (string)
    }
  ```

  - GET /v2/{tenant_id}/subscriptions?artifact_id={artifact_id}
  - DELETE /v2/{tenant_id}/subscriptions/{client_id}?artifact_id={artifact_id}

* Updated OpenAPI doc parse logic to handle client secret security policy